### PR TITLE
Resolve Timestamp String Issue in JSON Export

### DIFF
--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -172,7 +172,7 @@
                 }
                 for (let i = 0; i < this.event_list.length; ++i) {
                     this.event_list[i].number = Number(this.event_list[i].number);
-                    this.event_list[i].timestamp = Number(this.event_list[i].timestamp).toFixed(1);
+                    this.event_list[i].timestamp = Number(this.event_list[i].timestamp.toFixed(1));
                 }
                 const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(this.event_list));
                 const anchor = document.getElementById('download_anchor_element');


### PR DESCRIPTION
### Related Issue

Fixes #112 

### Proposed Changes

- Changed the `timestamp` field conversion in the `save_program` method to ensure it remains a number in the exported JSON file.
- This was achieved by converting the `timestamp` back to a number after using `.toFixed(1)`, addressing the issue where it was previously saved as a string.

### How to Test

1. Checkout to this branch.
2. Run the application and create a new fireworks program.
3. Add events with various timestamps.
4. Save the program and inspect the exported JSON file.
5. The `timestamp` field should now be a number, not a string.

### Checklist

- [X] Tested the changes locally.

### Reviewers

@CR1337 

### Additional Context

This change ensures that the data structure of the exported JSON aligns with the expected format, particularly for the `timestamp` field, improving the reliability of the load functionality.
